### PR TITLE
switch from system2 to sys for greater flexibility

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,7 +12,8 @@ RoxygenNote: 7.3.2
 Imports:
     digest,
     jsonlite,
-    rlang
-Suggests: 
+    rlang,
+    sys
+Suggests:
     testthat (>= 3.0.0)
 Config/testthat/edition: 3

--- a/man/exec_flowr.Rd
+++ b/man/exec_flowr.Rd
@@ -9,20 +9,20 @@ exec_flowr(
   args,
   verbose = FALSE,
   base_dir = get_default_node_base_dir(),
-  wait = TRUE
+  background = FALSE
 )
 }
 \arguments{
-\item{args}{The arguments to pass to the flowR CLI, as a character.}
+\item{args}{The arguments to pass to the flowR CLI, as a character vector.}
 
 \item{verbose}{Whether to print out information about the commands being executed.}
 
 \item{base_dir}{The base directory that Node and flowR were installed in. By default, this uses the package's installation directory through \code{\link[=get_default_node_base_dir]{get_default_node_base_dir()}}.}
 
-\item{wait}{Whether to wait for the command to finish before returning.}
+\item{background}{Whether the command should be executed as a background process.}
 }
 \value{
-The return value of the \code{\link[=exec_node_command]{exec_node_command()}} call.
+The return value of the \code{\link[=exec_node_command]{exec_node_command()}} call, which is the exit code if background is false, or the pid if background is true.
 }
 \description{
 Executes a local version of the flowR CLI with the given arguments in the given directory.

--- a/man/exec_node_command.Rd
+++ b/man/exec_node_command.Rd
@@ -10,22 +10,22 @@ exec_node_command(
   args,
   verbose = FALSE,
   base_dir = get_default_node_base_dir(),
-  wait = TRUE
+  background = FALSE
 )
 }
 \arguments{
 \item{app}{The node subcommand to run, which can be one of "node", "npm", or "npx".}
 
-\item{args}{The arguments to pass to the Node command, as a character.}
+\item{args}{The arguments to pass to the Node command, as a character vector.}
 
 \item{verbose}{Whether to print out information about the commands being executed.}
 
 \item{base_dir}{The base directory that Node was installed in. By default, this uses the package's installation directory through \code{\link[=get_default_node_base_dir]{get_default_node_base_dir()}}.}
 
-\item{wait}{Whether to wait for the command to finish before returning.}
+\item{background}{Whether the command should be executed as a background process.}
 }
 \value{
-The return value of the system2 call.
+The return value of the call, which is the exit code if background is false, or the pid if background is true.
 }
 \description{
 Executes the given Node subcommand in the given arguments in the given directory.


### PR DESCRIPTION
Essentially, `system2` doesn't ever return a pid when starting as a background process, meaning processes can never meaningfully be killed. This solves that issue.